### PR TITLE
Migrate remaining unsafe indexes to safe indexes except File

### DIFF
--- a/src/Object.zig
+++ b/src/Object.zig
@@ -657,7 +657,8 @@ pub fn resolveLiterals(self: *Object, lp: *MachO.LiteralPool, macho_file: *MachO
                 const atom_data = data[atom.off..][0..atom.size];
                 const res = try lp.insert(gpa, header.type(), atom_data);
                 if (!res.found_existing) {
-                    res.ref.* = .{ .index = atom.getExtra(macho_file).literal_symbol_index, .file = self.index };
+                    const literal_symbol_index: Symbol.Index = @enumFromInt(atom.getExtra(macho_file).literal_symbol_index);
+                    res.ref.* = literal_symbol_index.toRef(self.index).unwrap().?;
                 } else {
                     const lp_sym = lp.getSymbol(res.index, macho_file);
                     const lp_atom = lp_sym.getAtom(macho_file).?;
@@ -688,7 +689,8 @@ pub fn resolveLiterals(self: *Object, lp: *MachO.LiteralPool, macho_file: *MachO
                 const res = try lp.insert(gpa, header.type(), buffer.items[addend..]);
                 buffer.clearRetainingCapacity();
                 if (!res.found_existing) {
-                    res.ref.* = .{ .index = atom.getExtra(macho_file).literal_symbol_index, .file = self.index };
+                    const literal_symbol_index: Symbol.Index = @enumFromInt(atom.getExtra(macho_file).literal_symbol_index);
+                    res.ref.* = literal_symbol_index.toRef(self.index).unwrap().?;
                 } else {
                     const lp_sym = lp.getSymbol(res.index, macho_file);
                     const lp_atom = lp_sym.getAtom(macho_file).?;
@@ -716,10 +718,10 @@ pub fn dedupLiterals(self: *Object, lp: MachO.LiteralPool, macho_file: *MachO) v
         };
         for (relocs) |*rel| {
             if (rel.tag != .@"extern") continue;
-            const target_sym_ref = rel.getTargetSymbolRef(atom.*, macho_file);
-            const file = target_sym_ref.getFile(macho_file) orelse continue;
+            const target_sym_ref = rel.getTargetSymbolRef(atom.*, macho_file).unwrap() orelse continue;
+            const file = target_sym_ref.getFile(macho_file);
             if (file.getIndex() != self.index) continue;
-            const target_sym = target_sym_ref.getSymbol(macho_file).?;
+            const target_sym = target_sym_ref.getSymbol(macho_file);
             const target_atom = target_sym.getAtom(macho_file) orelse continue;
             const isec = target_atom.getInputSection(macho_file);
             if (!Object.isCstringLiteral(isec) and !Object.isFixedSizeLiteral(isec) and !Object.isPtrLiteral(isec)) continue;
@@ -842,7 +844,7 @@ fn initSymbols(self: *Object, allocator: Allocator, macho_file: *MachO) !void {
 
     for (slice.items(.nlist), slice.items(.atom), 0..) |nlist, atom_index, i| {
         const index = self.addSymbolAssumeCapacity();
-        const symbol = &self.symbols.items[index];
+        const symbol = &self.symbols.items[@intFromEnum(index)];
         symbol.value = nlist.n_value;
         symbol.name = .{ .pos = nlist.n_strx, .len = @intCast(self.getNStrx(nlist.n_strx).len + 1) };
         symbol.nlist_idx = @intCast(i);
@@ -888,12 +890,12 @@ fn initSymbolStabs(self: *Object, allocator: Allocator, nlists: anytype, macho_f
         ctx: *const Object,
         entries: @TypeOf(nlists),
 
-        fn find(fs: @This(), addr: u64) ?Symbol.Index {
+        fn find(fs: @This(), addr: u64) Symbol.OptionalIndex {
             // TODO binary search since we have the list sorted
             for (fs.entries) |nlist| {
-                if (nlist.nlist.n_value == addr) return @intCast(nlist.idx);
+                if (nlist.nlist.n_value == addr) return @enumFromInt(nlist.idx);
             }
-            return null;
+            return .none;
         }
     };
 
@@ -1113,7 +1115,7 @@ fn initEhFrameRecords(self: *Object, allocator: Allocator, sect_id: u8, file: Fi
                     });
                     return error.ParseFailed;
                 };
-                cie.personality = .{ .index = rel.target, .offset = rel.offset - cie.offset };
+                cie.personality = .{ .index = rel.target.symbol, .offset = rel.offset - cie.offset };
             },
             else => {},
         }
@@ -1127,12 +1129,12 @@ fn initUnwindRecords(self: *Object, allocator: Allocator, sect_id: u8, file: Fil
     const SymbolLookup = struct {
         ctx: *const Object,
 
-        fn find(fs: @This(), addr: u64) ?Symbol.Index {
+        fn find(fs: @This(), addr: u64) Symbol.OptionalIndex {
             for (0..fs.ctx.symbols.items.len) |i| {
                 const nlist = fs.ctx.symtab.items(.nlist)[i];
-                if (nlist.ext() and nlist.n_value == addr) return @intCast(i);
+                if (nlist.ext() and nlist.n_value == addr) return @enumFromInt(i);
             }
-            return null;
+            return .none;
         }
     };
 
@@ -1191,10 +1193,10 @@ fn initUnwindRecords(self: *Object, allocator: Allocator, sect_id: u8, file: Fil
                 },
                 16 => switch (rel.tag) { // personality function
                     .@"extern" => {
-                        out.personality = rel.target;
+                        out.personality = rel.target.symbol.toOptional();
                     },
-                    .local => if (sym_lookup.find(rec.personalityFunction)) |sym_index| {
-                        out.personality = sym_index;
+                    .local => if (sym_lookup.find(rec.personalityFunction).unwrap()) |sym_index| {
+                        out.personality = sym_index.toOptional();
                     } else {
                         macho_file.fatal("{}: {s},{s}: 0x{x}: bad relocation", .{
                             self.fmtPath(), header.segName(), header.sectName(), rel.offset,
@@ -1499,27 +1501,27 @@ pub fn resolveSymbols(self: *Object, macho_file: *MachO) !void {
             if (!atom.alive.load(.seq_cst)) continue;
         }
 
-        const gop = try macho_file.resolver.getOrPut(gpa, .{
-            .index = @intCast(i),
-            .file = self.index,
-        }, macho_file);
+        const sym_index: Symbol.Index = @enumFromInt(i);
+        const sym_ref = sym_index.toRef(self.index);
+        const gop = try macho_file.resolver.getOrPut(gpa, sym_ref.unwrap().?, macho_file);
         if (!gop.found_existing) {
-            gop.ref.* = .{ .index = 0, .file = 0 };
+            gop.ref.* = .none;
         }
         global.* = gop.index;
 
         if (nlist.undf() and !nlist.tentative()) continue;
-        if (gop.ref.getFile(macho_file) == null) {
-            gop.ref.* = .{ .index = @intCast(i), .file = self.index };
+
+        const gop_unwrapped_ref = gop.ref.unwrap() orelse {
+            gop.ref.* = sym_ref;
             continue;
-        }
+        };
 
         if (self.asFile().getSymbolRank(.{
             .archive = !self.alive,
             .weak = nlist.weakDef(),
             .tentative = nlist.tentative(),
-        }) < gop.ref.getSymbol(macho_file).?.getSymbolRank(macho_file)) {
-            gop.ref.* = .{ .index = @intCast(i), .file = self.index };
+        }) < gop_unwrapped_ref.getSymbol(macho_file).getSymbolRank(macho_file)) {
+            gop.ref.* = sym_ref;
         }
     }
 }
@@ -1532,9 +1534,9 @@ pub fn markLive(self: *Object, macho_file: *MachO) void {
         const nlist = self.symtab.items(.nlist)[i];
         if (!nlist.ext()) continue;
 
-        const ref = self.getSymbolRef(@intCast(i), macho_file);
-        const file = ref.getFile(macho_file) orelse continue;
-        const sym = ref.getSymbol(macho_file).?;
+        const ref = self.getSymbolRef(@enumFromInt(i), macho_file).unwrap() orelse continue;
+        const file = ref.getFile(macho_file);
+        const sym = ref.getSymbol(macho_file);
         const should_keep = nlist.undf() or (nlist.tentative() and !sym.flags.tentative);
         if (should_keep and file == .object and !file.object.alive) {
             file.object.alive = true;
@@ -1548,9 +1550,9 @@ pub fn mergeSymbolVisibility(self: *Object, macho_file: *MachO) void {
     defer tracy.end();
 
     for (self.symbols.items, 0..) |sym, i| {
-        const ref = self.getSymbolRef(@intCast(i), macho_file);
-        const global = ref.getSymbol(macho_file) orelse continue;
-        if (global.getFile(macho_file).? != .dylib) {
+        const ref = self.getSymbolRef(@enumFromInt(i), macho_file).unwrap() orelse continue;
+        const global = ref.getSymbol(macho_file);
+        if (global.getFile(macho_file).? != .dylib) { // TODO: shouldn't this be ref.getFile() != .dylib?
             if (macho_file.isMarkedForExport(global.getName(macho_file))) |is_export| {
                 global.visibility = if (is_export) .global else .hidden;
                 continue;
@@ -1597,11 +1599,12 @@ pub fn convertTentativeDefinitions(self: *Object, macho_file: *MachO) !void {
 
     for (self.symbols.items, self.globals.items, 0..) |*sym, off, i| {
         if (!sym.flags.tentative) continue;
-        if (macho_file.resolver.get(off).?.file != self.index) continue;
+        const global_ref = macho_file.resolver.get(off) orelse continue;
+        const global_ref_unwrapped = global_ref.unwrap() orelse continue;
+        if (global_ref_unwrapped.file != self.index) continue;
 
-        const nlist_idx = @as(Symbol.Index, @intCast(i));
-        const nlist = &self.symtab.items(.nlist)[nlist_idx];
-        const nlist_atom = &self.symtab.items(.atom)[nlist_idx];
+        const nlist = &self.symtab.items(.nlist)[i];
+        const nlist_atom = &self.symtab.items(.atom)[i];
 
         const name = try std.fmt.allocPrintZ(gpa, "__DATA$__common${s}", .{sym.getName(macho_file)});
         defer gpa.free(name);
@@ -1646,7 +1649,8 @@ pub fn claimUnresolved(self: *Object, macho_file: *MachO) void {
         if (!nlist.ext()) continue;
         if (!nlist.undf()) continue;
 
-        if (self.getSymbolRef(@intCast(i), macho_file).getFile(macho_file) != null) continue;
+        const sym_index: Symbol.Index = @enumFromInt(i);
+        if (self.getSymbolRef(sym_index, macho_file).unwrap() != null) continue;
 
         const is_import = switch (macho_file.options.undefined_treatment) {
             .@"error" => false,
@@ -1662,7 +1666,7 @@ pub fn claimUnresolved(self: *Object, macho_file: *MachO) void {
             sym.visibility = .global;
 
             const idx = self.globals.items[i];
-            macho_file.resolver.values.items[idx - 1] = .{ .index = @intCast(i), .file = self.index };
+            macho_file.resolver.values.items[idx - 1] = sym_index.toRef(self.index);
         }
     }
 }
@@ -1674,7 +1678,9 @@ pub fn claimUnresolvedRelocatable(self: *Object, macho_file: *MachO) void {
     for (self.symbols.items, self.symtab.items(.nlist), 0..) |*sym, nlist, i| {
         if (!nlist.ext()) continue;
         if (!nlist.undf()) continue;
-        if (self.getSymbolRef(@intCast(i), macho_file).getFile(macho_file) != null) continue;
+
+        const sym_index: Symbol.Index = @enumFromInt(i);
+        if (self.getSymbolRef(sym_index, macho_file).unwrap() != null) continue;
 
         sym.value = 0;
         sym.atom_ref = .none;
@@ -1683,7 +1689,7 @@ pub fn claimUnresolvedRelocatable(self: *Object, macho_file: *MachO) void {
         sym.visibility = .global;
 
         const idx = self.globals.items[i];
-        macho_file.resolver.values.items[idx - 1] = .{ .index = @intCast(i), .file = self.index };
+        macho_file.resolver.values.items[idx - 1] = sym_index.toRef(self.index);
     }
 }
 
@@ -1711,14 +1717,16 @@ pub fn stripLocalsRelocatable(self: *Object, macho_file: *MachO) !void {
     const gpa = macho_file.allocator;
 
     for (self.symbols.items, 0..) |*sym, i| {
-        const ref = self.getSymbolRef(@intCast(i), macho_file);
-        const file = ref.getFile(macho_file) orelse continue;
+        const ref = self.getSymbolRef(@enumFromInt(i), macho_file).unwrap() orelse continue;
+        const file = ref.getFile(macho_file);
         if (file.getIndex() != self.index) continue;
         if (sym.getAtom(macho_file)) |atom| if (!atom.alive.load(.seq_cst)) continue;
         if (sym.isSymbolStab(macho_file)) continue;
         if (!sym.isLocal()) continue;
         // Pad to
-        const name = try std.fmt.allocPrintZ(gpa, "l{d:0>3}", .{macho_file.strip_locals_counter.fetchAdd(1, .seq_cst)});
+        const name = try std.fmt.allocPrintZ(gpa, "l{d:0>3}", .{
+            macho_file.strip_locals_counter.fetchAdd(1, .seq_cst),
+        });
         defer gpa.free(name);
         sym.name = try self.addString(gpa, name);
     }
@@ -1729,8 +1737,8 @@ pub fn calcSymtabSize(self: *Object, macho_file: *MachO) void {
     defer tracy.end();
 
     for (self.symbols.items, 0..) |*sym, i| {
-        const ref = self.getSymbolRef(@intCast(i), macho_file);
-        const file = ref.getFile(macho_file) orelse continue;
+        const ref = self.getSymbolRef(@enumFromInt(i), macho_file).unwrap() orelse continue;
+        const file = ref.getFile(macho_file);
         if (file.getIndex() != self.index) continue;
         if (sym.getAtom(macho_file)) |atom| if (!atom.alive.load(.seq_cst)) continue;
         if (sym.isSymbolStab(macho_file)) continue;
@@ -1781,8 +1789,8 @@ pub fn calcStabsSize(self: *Object, macho_file: *MachO) void {
         }
 
         for (self.symbols.items, 0..) |sym, i| {
-            const ref = self.getSymbolRef(@intCast(i), macho_file);
-            const file = ref.getFile(macho_file) orelse continue;
+            const ref = self.getSymbolRef(@enumFromInt(i), macho_file).unwrap() orelse continue;
+            const file = ref.getFile(macho_file);
             if (file.getIndex() != self.index) continue;
             if (!sym.flags.output_symtab) continue;
             if (macho_file.options.relocatable) {
@@ -1992,8 +2000,8 @@ pub fn writeSymtab(self: Object, macho_file: *MachO) void {
 
     var n_strx = self.output_symtab_ctx.stroff;
     for (self.symbols.items, 0..) |sym, i| {
-        const ref = self.getSymbolRef(@intCast(i), macho_file);
-        const file = ref.getFile(macho_file) orelse continue;
+        const ref = self.getSymbolRef(@enumFromInt(i), macho_file).unwrap() orelse continue;
+        const file = ref.getFile(macho_file);
         if (file.getIndex() != self.index) continue;
         const idx = sym.getOutputSymtabIndex(macho_file) orelse continue;
         const out_sym = &macho_file.symtab.items[idx];
@@ -2113,8 +2121,8 @@ pub fn writeStabs(self: *const Object, stroff: u32, macho_file: *MachO) void {
         }
 
         for (self.symbols.items, 0..) |sym, i| {
-            const ref = self.getSymbolRef(@intCast(i), macho_file);
-            const file = ref.getFile(macho_file) orelse continue;
+            const ref = self.getSymbolRef(@enumFromInt(i), macho_file).unwrap() orelse continue;
+            const file = ref.getFile(macho_file);
             if (file.getIndex() != self.index) continue;
             if (!sym.flags.output_symtab) continue;
             if (macho_file.options.relocatable) {
@@ -2420,16 +2428,16 @@ fn addSymbol(self: *Object, allocator: Allocator) !Symbol.Index {
 }
 
 fn addSymbolAssumeCapacity(self: *Object) Symbol.Index {
-    const index: Symbol.Index = @intCast(self.symbols.items.len);
+    const index: Symbol.Index = @enumFromInt(self.symbols.items.len);
     const symbol = self.symbols.addOneAssumeCapacity();
     symbol.* = .{ .file = self.index };
     return index;
 }
 
-pub fn getSymbolRef(self: Object, index: Symbol.Index, macho_file: *MachO) MachO.Ref {
-    const global_index = self.globals.items[index];
+pub fn getSymbolRef(self: Object, index: Symbol.Index, macho_file: *MachO) Symbol.Ref {
+    const global_index = self.globals.items[@intFromEnum(index)];
     if (macho_file.resolver.get(global_index)) |ref| return ref;
-    return .{ .index = index, .file = self.index };
+    return index.toRef(self.index);
 }
 
 pub fn addSymbolExtra(self: *Object, allocator: Allocator, extra: Symbol.Extra) !u32 {
@@ -2628,12 +2636,11 @@ fn formatSymtab(
     const macho_file = ctx.macho_file;
     try writer.writeAll("  symbols\n");
     for (object.symbols.items, 0..) |sym, i| {
-        const ref = object.getSymbolRef(@intCast(i), macho_file);
-        if (ref.getFile(macho_file) == null) {
-            // TODO any better way of handling this?
-            try writer.print("    {s} : unclaimed\n", .{sym.getName(macho_file)});
+        const ref = object.getSymbolRef(@enumFromInt(i), macho_file);
+        if (ref.unwrap()) |unwrapped| {
+            try writer.print("    {}\n", .{unwrapped.getSymbol(macho_file).fmt(macho_file)});
         } else {
-            try writer.print("    {}\n", .{ref.getSymbol(macho_file).?.fmt(macho_file)});
+            try writer.print("    {s} : unclaimed\n", .{sym.getName(macho_file)});
         }
     }
     for (object.stab_files.items) |sf| {
@@ -2711,11 +2718,11 @@ const StabFile = struct {
 
     const Stab = struct {
         is_func: bool = true,
-        index: ?Symbol.Index = null,
+        index: Symbol.OptionalIndex = .none,
 
         fn getSymbol(stab: Stab, object: *const Object) ?*Symbol {
-            const index = stab.index orelse return null;
-            return &object.symbols.items[index];
+            const index = stab.index.unwrap() orelse return null;
+            return &object.symbols.items[@intFromEnum(index)];
         }
 
         pub fn format(
@@ -2748,11 +2755,11 @@ const StabFile = struct {
             const stab, const object = ctx;
             const sym = stab.getSymbol(object).?;
             if (stab.is_func) {
-                try writer.print("func({d})", .{stab.index.?});
+                try writer.print("func({d})", .{stab.index.unwrap().?});
             } else if (sym.visibility == .global) {
-                try writer.print("gsym({d})", .{stab.index.?});
+                try writer.print("gsym({d})", .{stab.index.unwrap().?});
             } else {
-                try writer.print("stsym({d})", .{stab.index.?});
+                try writer.print("stsym({d})", .{stab.index.unwrap().?});
             }
         }
     };
@@ -2820,7 +2827,7 @@ const x86_64 = struct {
             };
             var is_extern = rel.r_extern == 1;
 
-            const target: u32 = if (!is_extern) blk: {
+            const target: Relocation.Target = if (!is_extern) blk: {
                 const nsect = rel.r_symbolnum - 1;
                 const taddr: i64 = if (rel.r_pcrel == 1)
                     @as(i64, @intCast(sect.addr)) + rel.r_address + addend + 4
@@ -2837,10 +2844,10 @@ const x86_64 = struct {
                 const isec = target_atom.getInputSection(macho_file);
                 if (isCstringLiteral(isec) or isFixedSizeLiteral(isec) or isPtrLiteral(isec)) {
                     is_extern = true;
-                    break :blk target_atom.getExtra(macho_file).literal_symbol_index;
+                    break :blk .{ .symbol = @enumFromInt(target_atom.getExtra(macho_file).literal_symbol_index) };
                 }
-                break :blk @intFromEnum(target); // TODO: this cast should not be needed
-            } else rel.r_symbolnum;
+                break :blk .{ .atom = target };
+            } else .{ .symbol = @enumFromInt(rel.r_symbolnum) };
 
             const has_subtractor = if (i > 0 and
                 @as(macho.reloc_type_x86_64, @enumFromInt(relocs[i - 1].r_type)) == .X86_64_RELOC_SUBTRACTOR)
@@ -3006,7 +3013,7 @@ const aarch64 = struct {
             const rel_type: macho.reloc_type_arm64 = @enumFromInt(rel.r_type);
             var is_extern = rel.r_extern == 1;
 
-            const target: u32 = if (!is_extern) blk: {
+            const target: Relocation.Target = if (!is_extern) blk: {
                 const nsect = rel.r_symbolnum - 1;
                 const taddr: i64 = if (rel.r_pcrel == 1)
                     @as(i64, @intCast(sect.addr)) + rel.r_address + addend
@@ -3023,10 +3030,10 @@ const aarch64 = struct {
                 const isec = target_atom.getInputSection(macho_file);
                 if (isCstringLiteral(isec) or isFixedSizeLiteral(isec) or isPtrLiteral(isec)) {
                     is_extern = true;
-                    break :blk target_atom.getExtra(macho_file).literal_symbol_index;
+                    break :blk .{ .symbol = @enumFromInt(target_atom.getExtra(macho_file).literal_symbol_index) };
                 }
-                break :blk @intFromEnum(target); // TODO: this cast should not be needed
-            } else rel.r_symbolnum;
+                break :blk .{ .atom = target };
+            } else .{ .symbol = @enumFromInt(rel.r_symbolnum) };
 
             const has_subtractor = if (i > 0 and
                 @as(macho.reloc_type_arm64, @enumFromInt(relocs[i - 1].r_type)) == .ARM64_RELOC_SUBTRACTOR)

--- a/src/Symbol.zig
+++ b/src/Symbol.zig
@@ -464,7 +464,10 @@ pub const UnwrappedRef = struct {
     file: File.Index,
 
     pub fn getSymbol(ref: UnwrappedRef, macho_file: *MachO) *Symbol {
-        return ref.getSymbol(macho_file);
+        const file = macho_file.getFile(ref.file).?;
+        return switch (file) {
+            inline else => |x| &x.symbols.items[@intFromEnum(ref.symbol)],
+        };
     }
 
     pub fn getFile(ref: UnwrappedRef, macho_file: *MachO) File {

--- a/src/UnwindInfo.zig
+++ b/src/UnwindInfo.zig
@@ -556,7 +556,9 @@ pub const Record = struct {
         if (!rec.alive) try writer.writeAll(" : [*]");
     }
 
-    pub const Index = u32;
+    pub const Index = enum(u32) {
+        _,
+    };
 
     // TODO convert into MachO.Ref
     pub const Ref = struct {

--- a/src/UnwindInfo.zig
+++ b/src/UnwindInfo.zig
@@ -469,7 +469,7 @@ pub const Record = struct {
     lsda: Atom.OptionalIndex = .none,
     lsda_offset: u32 = 0,
     personality: ?Symbol.Index = null, // TODO make this zero-is-null
-    fde: Fde.Index = 0, // TODO actually make FDE at 0 an invalid FDE
+    fde: Fde.OptionalIndex = .none,
     alive: bool = true,
 
     pub fn getObject(rec: Record, macho_file: *MachO) *Object {
@@ -493,12 +493,14 @@ pub const Record = struct {
 
     pub fn getFde(rec: Record, macho_file: *MachO) ?Fde {
         if (!rec.enc.isDwarf(macho_file)) return null;
-        return rec.getObject(macho_file).fdes.items[rec.fde];
+        const fde_index = rec.fde.unwrap() orelse return null;
+        return rec.getObject(macho_file).fdes.items[@intFromEnum(fde_index)];
     }
 
     pub fn getFdePtr(rec: Record, macho_file: *MachO) ?*Fde {
         if (!rec.enc.isDwarf(macho_file)) return null;
-        return &rec.getObject(macho_file).fdes.items[rec.fde];
+        const fde_index = rec.fde.unwrap() orelse return null;
+        return &rec.getObject(macho_file).fdes.items[@intFromEnum(fde_index)];
     }
 
     pub fn getAtomAddress(rec: Record, macho_file: *MachO) u64 {

--- a/src/dyld_info/Rebase.zig
+++ b/src/dyld_info/Rebase.zig
@@ -63,7 +63,7 @@ pub fn updateSize(rebase: *Rebase, macho_file: *MachO) !void {
         const seg_id = macho_file.sections.items(.segment_id)[sid];
         const seg = macho_file.segments.items[seg_id];
         for (macho_file.got.symbols.items, 0..) |ref, idx| {
-            const sym = ref.getSymbol(macho_file).?;
+            const sym = ref.getSymbol(macho_file);
             const addr = macho_file.got.getAddress(@intCast(idx), macho_file);
             if (!sym.flags.import) {
                 try rebase.entries.append(gpa, .{
@@ -79,7 +79,7 @@ pub fn updateSize(rebase: *Rebase, macho_file: *MachO) !void {
         const seg_id = macho_file.sections.items(.segment_id)[sid];
         const seg = macho_file.segments.items[seg_id];
         for (macho_file.stubs.symbols.items, 0..) |ref, idx| {
-            const sym = ref.getSymbol(macho_file).?;
+            const sym = ref.getSymbol(macho_file);
             const addr = sect.addr + idx * @sizeOf(u64);
             const rebase_entry = Rebase.Entry{
                 .offset = addr - seg.vmaddr,
@@ -95,7 +95,7 @@ pub fn updateSize(rebase: *Rebase, macho_file: *MachO) !void {
         const seg_id = macho_file.sections.items(.segment_id)[sid];
         const seg = macho_file.segments.items[seg_id];
         for (macho_file.tlv_ptr.symbols.items, 0..) |ref, idx| {
-            const sym = ref.getSymbol(macho_file).?;
+            const sym = ref.getSymbol(macho_file);
             const addr = macho_file.tlv_ptr.getAddress(@intCast(idx), macho_file);
             if (!sym.flags.import) {
                 try rebase.entries.append(gpa, .{

--- a/src/dyld_info/Trie.zig
+++ b/src/dyld_info/Trie.zig
@@ -99,8 +99,8 @@ pub fn updateSize(self: *Trie, macho_file: *MachO) !void {
 
     const seg = macho_file.getTextSegment();
     for (macho_file.resolver.values.items) |ref| {
-        if (ref.getFile(macho_file) == null) continue;
-        const sym = ref.getSymbol(macho_file).?;
+        const unwrapped = ref.unwrap() orelse continue;
+        const sym = unwrapped.getSymbol(macho_file);
         if (!sym.flags.@"export") continue;
         if (sym.getAtom(macho_file)) |atom| if (!atom.alive.load(.seq_cst)) continue;
         var flags: u64 = if (sym.flags.abs)

--- a/src/eh_frame.zig
+++ b/src/eh_frame.zig
@@ -69,7 +69,7 @@ pub const Cie = struct {
     pub fn getPersonality(cie: Cie, macho_file: *MachO) ?*Symbol {
         const personality = cie.personality orelse return null;
         const object = cie.getObject(macho_file);
-        return object.getSymbolRef(personality.index, macho_file).getSymbol(macho_file);
+        return object.getSymbolRef(personality.index, macho_file).unwrap().?.getSymbol(macho_file);
     }
 
     pub fn eql(cie: Cie, other: Cie, macho_file: *MachO) bool {
@@ -127,7 +127,7 @@ pub const Cie = struct {
     };
 
     pub const Personality = struct {
-        index: Symbol.Index = 0,
+        index: Symbol.Index,
         offset: u32 = 0,
     };
 };

--- a/src/relocatable.zig
+++ b/src/relocatable.zig
@@ -57,8 +57,8 @@ fn markExports(macho_file: *MachO) void {
     for (macho_file.objects.items) |index| {
         const object = macho_file.getFile(index).?.object;
         for (object.symbols.items, 0..) |*sym, i| {
-            const ref = object.getSymbolRef(@intCast(i), macho_file);
-            const file = ref.getFile(macho_file) orelse continue;
+            const ref = object.getSymbolRef(@enumFromInt(i), macho_file).unwrap() orelse continue;
+            const file = ref.getFile(macho_file);
             if (file.getIndex() != index) continue;
             if (sym.visibility != .global) continue;
             sym.flags.@"export" = true;

--- a/src/synthetic.zig
+++ b/src/synthetic.zig
@@ -1,5 +1,5 @@
 pub const GotSection = struct {
-    symbols: std.ArrayListUnmanaged(MachO.Ref) = .{},
+    symbols: std.ArrayListUnmanaged(Symbol.UnwrappedRef) = .{},
 
     pub const Index = u32;
 
@@ -7,12 +7,12 @@ pub const GotSection = struct {
         got.symbols.deinit(allocator);
     }
 
-    pub fn addSymbol(got: *GotSection, ref: MachO.Ref, macho_file: *MachO) !void {
+    pub fn addSymbol(got: *GotSection, ref: Symbol.UnwrappedRef, macho_file: *MachO) !void {
         const gpa = macho_file.allocator;
         const index = @as(Index, @intCast(got.symbols.items.len));
         const entry = try got.symbols.addOne(gpa);
         entry.* = ref;
-        const symbol = ref.getSymbol(macho_file).?;
+        const symbol = ref.getSymbol(macho_file);
         symbol.addExtra(.{ .got = index }, macho_file);
     }
 
@@ -30,7 +30,7 @@ pub const GotSection = struct {
         const tracy = trace(@src());
         defer tracy.end();
         for (got.symbols.items) |ref| {
-            const sym = ref.getSymbol(macho_file).?;
+            const sym = ref.getSymbol(macho_file);
             const value = if (sym.flags.import) @as(u64, 0) else sym.getAddress(.{}, macho_file);
             try writer.writeInt(u64, value, .little);
         }
@@ -54,7 +54,7 @@ pub const GotSection = struct {
         _ = options;
         _ = unused_fmt_string;
         for (ctx.got.symbols.items, 0..) |ref, i| {
-            const symbol = ref.getSymbol(ctx.macho_file).?;
+            const symbol = ref.getSymbol(ctx.macho_file);
             try writer.print("  {d}@0x{x} => {}@0x{x} ({s})\n", .{
                 i,
                 symbol.getGotAddress(ctx.macho_file),
@@ -67,7 +67,7 @@ pub const GotSection = struct {
 };
 
 pub const StubsSection = struct {
-    symbols: std.ArrayListUnmanaged(MachO.Ref) = .{},
+    symbols: std.ArrayListUnmanaged(Symbol.UnwrappedRef) = .{},
 
     pub const Index = u32;
 
@@ -75,12 +75,12 @@ pub const StubsSection = struct {
         stubs.symbols.deinit(allocator);
     }
 
-    pub fn addSymbol(stubs: *StubsSection, ref: MachO.Ref, macho_file: *MachO) !void {
+    pub fn addSymbol(stubs: *StubsSection, ref: Symbol.UnwrappedRef, macho_file: *MachO) !void {
         const gpa = macho_file.allocator;
         const index = @as(Index, @intCast(stubs.symbols.items.len));
         const entry = try stubs.symbols.addOne(gpa);
         entry.* = ref;
-        const symbol = ref.getSymbol(macho_file).?;
+        const symbol = ref.getSymbol(macho_file);
         symbol.addExtra(.{ .stubs = index }, macho_file);
     }
 
@@ -102,7 +102,7 @@ pub const StubsSection = struct {
         const laptr_sect = macho_file.sections.items(.header)[macho_file.la_symbol_ptr_sect_index.?];
 
         for (stubs.symbols.items, 0..) |ref, idx| {
-            const sym = ref.getSymbol(macho_file).?;
+            const sym = ref.getSymbol(macho_file);
             const source = sym.getAddress(.{ .stubs = true }, macho_file);
             const target = laptr_sect.addr + idx * @sizeOf(u64);
             switch (cpu_arch) {
@@ -145,7 +145,7 @@ pub const StubsSection = struct {
         _ = options;
         _ = unused_fmt_string;
         for (ctx.stubs.symbols.items, 0..) |ref, i| {
-            const symbol = ref.getSymbol(ctx.macho_file).?;
+            const symbol = ref.getSymbol(ctx.macho_file);
             try writer.print("  {d}@0x{x} => {}@0x{x} ({s})\n", .{
                 i,
                 symbol.getStubsAddress(ctx.macho_file),
@@ -181,7 +181,7 @@ pub const StubsHelperSection = struct {
         const cpu_arch = macho_file.options.cpu_arch.?;
         var s: usize = preambleSize(cpu_arch);
         for (macho_file.stubs.symbols.items) |ref| {
-            const sym = ref.getSymbol(macho_file).?;
+            const sym = ref.getSymbol(macho_file);
             if (sym.flags.weak) continue;
             s += entrySize(cpu_arch);
         }
@@ -201,7 +201,7 @@ pub const StubsHelperSection = struct {
 
         var idx: usize = 0;
         for (macho_file.stubs.symbols.items) |ref| {
-            const sym = ref.getSymbol(macho_file).?;
+            const sym = ref.getSymbol(macho_file);
             if (sym.flags.weak) continue;
             const offset = macho_file.lazy_bind.offsets.items[idx];
             const source: i64 = @intCast(sect.addr + preamble_size + entry_size * idx);
@@ -239,11 +239,11 @@ pub const StubsHelperSection = struct {
         const cpu_arch = macho_file.options.cpu_arch.?;
         const sect = macho_file.sections.items(.header)[macho_file.stubs_helper_sect_index.?];
         const dyld_private_addr = target: {
-            const sym = obj.getDyldPrivateRef(macho_file).?.getSymbol(macho_file).?;
+            const sym = obj.getDyldPrivateRef(macho_file).?.unwrap().?.getSymbol(macho_file);
             break :target sym.getAddress(.{}, macho_file);
         };
         const dyld_stub_binder_addr = target: {
-            const sym = obj.getDyldStubBinderRef(macho_file).?.getSymbol(macho_file).?;
+            const sym = obj.getDyldStubBinderRef(macho_file).?.unwrap().?.getSymbol(macho_file);
             break :target sym.getGotAddress(macho_file);
         };
         switch (cpu_arch) {
@@ -300,7 +300,7 @@ pub const LaSymbolPtrSection = struct {
         const sect = macho_file.sections.items(.header)[macho_file.stubs_helper_sect_index.?];
         var stub_helper_idx: u32 = 0;
         for (macho_file.stubs.symbols.items) |ref| {
-            const sym = ref.getSymbol(macho_file).?;
+            const sym = ref.getSymbol(macho_file);
             if (sym.flags.weak) {
                 const value = sym.getAddress(.{ .stubs = false }, macho_file);
                 try writer.writeInt(u64, @intCast(value), .little);
@@ -315,7 +315,7 @@ pub const LaSymbolPtrSection = struct {
 };
 
 pub const TlvPtrSection = struct {
-    symbols: std.ArrayListUnmanaged(MachO.Ref) = .{},
+    symbols: std.ArrayListUnmanaged(Symbol.UnwrappedRef) = .{},
 
     pub const Index = u32;
 
@@ -323,12 +323,12 @@ pub const TlvPtrSection = struct {
         tlv.symbols.deinit(allocator);
     }
 
-    pub fn addSymbol(tlv: *TlvPtrSection, ref: MachO.Ref, macho_file: *MachO) !void {
+    pub fn addSymbol(tlv: *TlvPtrSection, ref: Symbol.UnwrappedRef, macho_file: *MachO) !void {
         const gpa = macho_file.allocator;
         const index = @as(Index, @intCast(tlv.symbols.items.len));
         const entry = try tlv.symbols.addOne(gpa);
         entry.* = ref;
-        const symbol = ref.getSymbol(macho_file).?;
+        const symbol = ref.getSymbol(macho_file);
         symbol.addExtra(.{ .tlv_ptr = index }, macho_file);
     }
 
@@ -347,7 +347,7 @@ pub const TlvPtrSection = struct {
         defer tracy.end();
 
         for (tlv.symbols.items) |ref| {
-            const sym = ref.getSymbol(macho_file).?;
+            const sym = ref.getSymbol(macho_file);
             if (sym.flags.import) {
                 try writer.writeInt(u64, 0, .little);
             } else {
@@ -374,7 +374,7 @@ pub const TlvPtrSection = struct {
         _ = options;
         _ = unused_fmt_string;
         for (ctx.tlv.symbols.items, 0..) |ref, i| {
-            const symbol = ref.getSymbol(ctx.macho_file).?;
+            const symbol = ref.getSymbol(ctx.macho_file);
             try writer.print("  {d}@0x{x} => {}@0x{x} ({s})\n", .{
                 i,
                 symbol.getTlvPtrAddress(ctx.macho_file),
@@ -387,7 +387,7 @@ pub const TlvPtrSection = struct {
 };
 
 pub const ObjcStubsSection = struct {
-    symbols: std.ArrayListUnmanaged(MachO.Ref) = .{},
+    symbols: std.ArrayListUnmanaged(Symbol.UnwrappedRef) = .{},
 
     pub fn deinit(objc: *ObjcStubsSection, allocator: Allocator) void {
         objc.symbols.deinit(allocator);
@@ -401,12 +401,12 @@ pub const ObjcStubsSection = struct {
         };
     }
 
-    pub fn addSymbol(objc: *ObjcStubsSection, ref: MachO.Ref, macho_file: *MachO) !void {
+    pub fn addSymbol(objc: *ObjcStubsSection, ref: Symbol.UnwrappedRef, macho_file: *MachO) !void {
         const gpa = macho_file.allocator;
         const index = @as(Index, @intCast(objc.symbols.items.len));
         const entry = try objc.symbols.addOne(gpa);
         entry.* = ref;
-        const symbol = ref.getSymbol(macho_file).?;
+        const symbol = ref.getSymbol(macho_file);
         symbol.addExtra(.{ .objc_stubs = index }, macho_file);
     }
 
@@ -427,7 +427,7 @@ pub const ObjcStubsSection = struct {
         const obj = macho_file.getInternalObject().?;
 
         for (objc.symbols.items, 0..) |ref, idx| {
-            const sym = ref.getSymbol(macho_file).?;
+            const sym = ref.getSymbol(macho_file);
             const addr = objc.getAddress(@intCast(idx), macho_file);
             switch (macho_file.options.cpu_arch.?) {
                 .x86_64 => {
@@ -439,7 +439,7 @@ pub const ObjcStubsSection = struct {
                     }
                     try writer.writeAll(&.{ 0xff, 0x25 });
                     {
-                        const target_sym = obj.getObjcMsgSendRef(macho_file).?.getSymbol(macho_file).?;
+                        const target_sym = obj.getObjcMsgSendRef(macho_file).?.unwrap().?.getSymbol(macho_file);
                         const target = target_sym.getGotAddress(macho_file);
                         const source = addr + 7;
                         try writer.writeInt(i32, @intCast(target - source - 2 - 4), .little);
@@ -459,7 +459,7 @@ pub const ObjcStubsSection = struct {
                         );
                     }
                     {
-                        const target_sym = obj.getObjcMsgSendRef(macho_file).?.getSymbol(macho_file).?;
+                        const target_sym = obj.getObjcMsgSendRef(macho_file).?.unwrap().?.getSymbol(macho_file);
                         const target = target_sym.getGotAddress(macho_file);
                         const source = addr + 2 * @sizeOf(u32);
                         const pages = try aarch64.calcNumberOfPages(@intCast(source), @intCast(target));
@@ -499,7 +499,7 @@ pub const ObjcStubsSection = struct {
         _ = options;
         _ = unused_fmt_string;
         for (ctx.objc.symbols.items, 0..) |ref, i| {
-            const symbol = ref.getSymbol(ctx.macho_file).?;
+            const symbol = ref.getSymbol(ctx.macho_file);
             try writer.print("  {d}@0x{x} => {}@0x{x} ({s})\n", .{
                 i,
                 symbol.getObjcStubsAddress(ctx.macho_file),
@@ -530,17 +530,17 @@ pub const Indsymtab = struct {
         _ = ind;
 
         for (macho_file.stubs.symbols.items) |ref| {
-            const sym = ref.getSymbol(macho_file).?;
+            const sym = ref.getSymbol(macho_file);
             try writer.writeInt(u32, sym.getOutputSymtabIndex(macho_file).?, .little);
         }
 
         for (macho_file.got.symbols.items) |ref| {
-            const sym = ref.getSymbol(macho_file).?;
+            const sym = ref.getSymbol(macho_file);
             try writer.writeInt(u32, sym.getOutputSymtabIndex(macho_file).?, .little);
         }
 
         for (macho_file.stubs.symbols.items) |ref| {
-            const sym = ref.getSymbol(macho_file).?;
+            const sym = ref.getSymbol(macho_file);
             try writer.writeInt(u32, sym.getOutputSymtabIndex(macho_file).?, .little);
         }
     }


### PR DESCRIPTION
This finishes migration of remaining indexes to safe indexes with the exception of `File` which will be done in a follow-up.

As an interesting observation, I believe that thanks to the rewrite of indexes, `bold` got a tiny bit faster, dropping below 1s when linking Zig's stage3 compiler (I have used an old setup for Zig so your mileage may vary when tested against up-to-date Zig repo!). Anyhow, the results:

<img width="1282" alt="Screenshot 2025-03-29 at 06 46 30" src="https://github.com/user-attachments/assets/638b4d67-ff2a-4640-b185-6390ad547205" />

Note that now we've got only Apple rewritten `ld` to beat!